### PR TITLE
"npm start" now runs project in dev mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "webpack-dev-server --config webpack.dev.config.js --open",
+    "start": "webpack-dev-server --config webpack.dev.config.js --open",
     "build": "webpack --config webpack.production.config.js"
   },
   "repository": {


### PR DESCRIPTION
Using "start" shortcut would be mush more convinient and clear for developers.